### PR TITLE
Make average_benchmarks more generic and support non-instrumented Chrome versions

### DIFF
--- a/src/tests_performance/test.py
+++ b/src/tests_performance/test.py
@@ -11,7 +11,7 @@ from common.utils import measure_time
 from common.utils import pretty_json
 from common.utils import print_debug
 from common.utils import average_benchmarks
-from common.utils import extract_rtbh_test_stats_json
+from common.utils import extract_rtbh_test_stats
 
 logger = logging.getLogger(__file__)
 
@@ -47,5 +47,5 @@ class PerformanceTest(BaseTest):
             bid_duration_ms = int(report_result_signals.get('browserSignals').get('bid_duration')) / 1000
             logger.info(f"generateBid took: {bid_duration_ms} ms")
 
-        return extract_rtbh_test_stats_json(report_result_signals)
+        return extract_rtbh_test_stats(report_result_signals)
 

--- a/src/tests_webassembly/test.py
+++ b/src/tests_webassembly/test.py
@@ -6,7 +6,7 @@ import logging
 from common.base_test import BaseTest
 from common.mockserver import MockServer
 from common.utils import print_debug, measure_time, log_exception, MeasureDuration, pretty_json,\
-    average_benchmarks, extract_rtbh_test_stats_json
+    average_benchmarks, extract_rtbh_test_stats
 
 logger = logging.getLogger(__file__)
 
@@ -42,4 +42,4 @@ class WebassemblyTest(BaseTest):
             bid_duration_ms = int(report_result_signals.get('browserSignals').get('bid_duration')) / 1000
             logger.info(f"generateBid took: {bid_duration_ms} ms")
 
-        return extract_rtbh_test_stats_json(report_result_signals)
+        return extract_rtbh_test_stats(report_result_signals)

--- a/src/tests_webassembly_api/test.py
+++ b/src/tests_webassembly_api/test.py
@@ -6,7 +6,7 @@ import logging
 from common.base_test import BaseTest
 from common.mockserver import MockServer
 from common.utils import print_debug, measure_time, log_exception, MeasureDuration, pretty_json,\
-    average_benchmarks, extract_rtbh_test_stats_json
+    average_benchmarks, extract_rtbh_test_stats
 
 logger = logging.getLogger(__file__)
 
@@ -42,4 +42,4 @@ class WebassemblyApiTest(BaseTest):
             bid_duration_ms = int(report_result_signals.get('browserSignals').get('bid_duration')) / 1000
             logger.info(f"generateBid took: {bid_duration_ms} ms")
 
-        return extract_rtbh_test_stats_json(report_result_signals)
+        return extract_rtbh_test_stats(report_result_signals)


### PR DESCRIPTION
extract_rtbh_test_stats() now returns a dict with any float values instead of a jsonized dict with microseconds like extract_rtbh_test_stats_json did