### PR TITLE
implement support for user-provided test library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ ENV CHROME_HEADLESS=1
 
 USER usertd
 
+# Note: run.sh depends on this WORKDIR path
+WORKDIR /home/usertd/tests
+
 COPY src/requirements.txt .
 RUN pip3 install --user -r requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update && \
 ENV CHROME_HEADLESS=1
 
 USER usertd
+
+# Note: run.sh depends on this WORKDIR path
 WORKDIR /home/usertd/tests
 
 COPY src/requirements.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,6 @@ ENV CHROME_HEADLESS=1
 
 USER usertd
 
-# Note: run.sh depends on this WORKDIR path
-WORKDIR /home/usertd/tests
-
 COPY src/requirements.txt .
 RUN pip3 install --user -r requirements.txt
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-docker build . -f Dockerfile.node --iidfile .iidfile.node
-
-docker run --rm `cat .iidfile.node` node tests_tensorflow/resources/buyer/build_buyer.js > tests_tensorflow/resources/buyer/buyer.js

--- a/run.sh
+++ b/run.sh
@@ -134,6 +134,8 @@ if [[ -v TEST_DIR ]] && [[ -n "${TEST_DIR}" ]]; then
   find ${TEST_DIR} -type f -print0 | xargs -0 chmod o+r,g+r
 fi
 
+# Note: container's WORKDIR is /home/usertd/tests , which is where TEST_DIR and TEST_LIB_DIR are mounted.
+#       This way we can skip PYTHONPATH setting.
 docker run --rm -i \
   ${termOpt} \
   -v "${CHROMIUM_DIR}:/home/usertd/chromium/" \

--- a/run.sh
+++ b/run.sh
@@ -122,12 +122,10 @@ trap cleanup EXIT
 touch "${HERE}/chromedriver.log"
 chmod a+w "${HERE}/chromedriver.log"
 
-# Note: we set UID and GID to those of the current user, to avoid permission denied errors when reading files.
 # Note: container's WORKDIR is /home/usertd/tests , which is where TEST_DIR and TEST_LIB_DIR are mounted.
 #       This way we can skip PYTHONPATH setting.
 # Note: TEST_DIR and TEST_LIB_DIR volumes are mounted read-only.
 docker run --rm -i \
-  --user $(id -u):$(id -g) \
   --workdir /home/usertd/tests/ \
   ${termOpt} \
   -v "${CHROMIUM_DIR}:/home/usertd/chromium/" \

--- a/run.sh
+++ b/run.sh
@@ -137,6 +137,7 @@ fi
 # Note: container's WORKDIR is /home/usertd/tests , which is where TEST_DIR and TEST_LIB_DIR are mounted.
 #       This way we can skip PYTHONPATH setting.
 docker run --rm -i \
+  --workdir /home/usertd/tests/ \
   ${termOpt} \
   -v "${CHROMIUM_DIR}:/home/usertd/chromium/" \
   -e CHROMIUM_DIR=/home/usertd/chromium \

--- a/src/run_tests.sh
+++ b/src/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ -z TEST_LIB_DIR ]] && [[ -n "${TEST_LIB_DIR}" ]]; then
+if [[ -v TEST_LIB_DIR ]] && [[ -n "${TEST_LIB_DIR}" ]]; then
   export PYTHONPATH="${TEST_LIB_DIR}:${PYTHONPATH}"
 fi
 

--- a/src/run_tests.sh
+++ b/src/run_tests.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+if [[ -z TEST_LIB_DIR ]] && [[ -n "${TEST_LIB_DIR}" ]]; then
+  export PYTHONPATH="${TEST_LIB_DIR}:${PYTHONPATH}"
+fi
+
 python3 -m unittest $TEST --verbose

--- a/src/run_tests.sh
+++ b/src/run_tests.sh
@@ -1,7 +1,3 @@
 #!/bin/bash
 
-if [[ -v TEST_LIB_DIR ]] && [[ -n "${TEST_LIB_DIR}" ]]; then
-  export PYTHONPATH="${TEST_LIB_DIR}:${PYTHONPATH}"
-fi
-
 python3 -m unittest $TEST --verbose


### PR DESCRIPTION
1. implements support for the test library, which can be supplied alongsite the tests using the new `--test-lib-dir` command-line option of `run.sh`
2. fixes permission problems (`TEST_DIR`)
3. removes `build.sh` (apparently unused)
