### PR TITLE
Run docker container with --init

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -126,6 +126,7 @@ chmod a+w "${HERE}/chromedriver.log"
 #       This way we can skip PYTHONPATH setting.
 # Note: TEST_DIR and TEST_LIB_DIR volumes are mounted read-only.
 docker run --rm -i \
+  --init \
   --workdir /home/usertd/tests/ \
   ${termOpt} \
   -v "${CHROMIUM_DIR}:/home/usertd/chromium/" \


### PR DESCRIPTION
This way signals will be handled correctly and sending a single SIGTERM to the docker run command will kill the whole container.